### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,19 +6,19 @@
 # Class (KEYWORD3)
 #######################################
 
-Ciao  KEYWORD3
-CiaoData  KEYWORD3
-Wifi  KEYWORD3
-WifiData  KEYWORD3
+Ciao	KEYWORD3
+CiaoData	KEYWORD3
+Wifi	KEYWORD3
+WifiData	KEYWORD3
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
 
-writeResponse KEYWORD2
-available KEYWORD2
-read  KEYWORD2
-write KEYWORD2
+writeResponse	KEYWORD2
+available	KEYWORD2
+read	KEYWORD2
+write	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords